### PR TITLE
Update relational.js

### DIFF
--- a/relational.js
+++ b/relational.js
@@ -13,7 +13,7 @@ adapter._init = function(options) {
     host: options.host,
     database: options.db,
     protocol: options.adapter,
-    username: options.username,
+    user: options.username,
     password: options.password,
     port: options.port,
     query: options.flags


### PR DESCRIPTION
orm.connect({}) looks for the "user" property and defaults to "root" if none present, this change will allow fortune to pass its "username" property through to orm so that the correct user it used for the database
