### PR TITLE
Added operators to filters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -165,9 +165,54 @@ export default Adapter => class PostgreSQLAdapter extends Adapter {
 
     for (let field in options.match) {
       const value = options.match[field]
-      const isArray = fields[field][isArrayKey]
+      const isArray = (fields[field] ?
+              fields[field][isArrayKey] :
+              fields[field.split('_')[0]][isArrayKey])
+      const containsOperator = field.includes('_')
+      const operator = (containsOperator ? field.split('_')[1] : null)
 
       if (!isArray) {
+        if (containsOperator) {
+          let sqlOperator;
+          switch (operator) {
+            case 'null':
+              where.push(`"${field.split('_')[0]}" is null`)
+              break;
+            case 'notnull':
+            where.push(`"${field.split('_')[0]}" is not null`)
+              break;
+            default:
+              switch (operator) {
+                case 'not':
+                  sqlOperator = '!='
+                  break;
+                case 'lt':
+                case 'before':
+                  sqlOperator = '<'
+                  break;
+                case 'gt':
+                case 'after':
+                  sqlOperator = '>'
+                  break;
+                case 'lte':
+                  sqlOperator = '<='
+                  break;
+                case 'gte':
+                  sqlOperator = '>='
+                  break;
+                case 'like':
+                  sqlOperator = 'like'
+                  break;
+                default:
+                  sqlOperator = '='
+              }
+              index++
+              parameters.push(inputValue(value))
+              where.push(`"${field.split('_')[0]}" ${sqlOperator} $${index}`)
+          }
+          continue
+        }
+
         if (Array.isArray(value))
           where.push(`"${field}" in (${value.map(mapValue).join(', ')})`)
         else {
@@ -203,6 +248,8 @@ export default Adapter => class PostgreSQLAdapter extends Adapter {
 
     const findRecords = query(
       `${selectColumns} ${where} ${order} ${slice}`, parameters)
+
+      console.log(findRecords)
 
     // Parallelize the find method with count method.
     return Promise.all([


### PR DESCRIPTION
ex: name_like
birthDate_before
birthDate_after
numberOfItems_gt
numberOfItems_lt

we can now use the keyword after the underscore for custom queries.
confer the way endpoints is doing it:

born_before: function (qb, value) {
return qb.where('date_of_birth', '<', value);
},
born_after: function (qb, value) {
return qb.where('date_of_birth', '>', value);
}