### PR TITLE
Update pg to v6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "pg": "^4.5.6"
+    "pg": "6.0.3"
   },
   "optionalDependencies": {
     "pg-native": "^1.10.0"


### PR DESCRIPTION
In [node-postgres version v6.x](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#v600), the internal pooling has been replaced with [pg-pool](https://www.npmjs.com/package/pg-pool).

This resolves https://github.com/fortunejs/fortune-postgres/issues/14 for me.