### PR TITLE
Cast integers when searching arrays

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -297,7 +297,13 @@ module.exports = Adapter => class PostgreSQLAdapter extends Adapter {
     function mapValueCast (value) {
       index++
       parameters.push(value)
-      return `$${index}${Buffer.isBuffer(value) ? '::bytea' : ''}`
+      let cast = '';
+      if (Buffer.isBuffer(value)) {
+        cast = '::bytea'
+      } else if (typeof value === 'number' && value % 1 === 0) {
+        cast = '::int'
+      }
+      return `$${index}${cast}`
     }
 
     function mapValue (value) {


### PR DESCRIPTION
I was trying to search via an array relationship, e.g:

```bash
// Training plan definition
module.exports = {
  title: { type: String },
  description: { type: String },
  image: { type: String },
  // Relationships
  users: { link: 'users', isArray: true, inverse: 'trainingPlans' }
};
```

```bash
store.find('training_plans', null, {
  match: {
    users: [1, 2]
  }
})
```

but I kept getting the following pg error:

```bash
error: operator does not exist: integer[] @> text[]
```

with the hint:

```bash
No operator matches the given name and argument type(s). You might need to add explicit type casts
```

This really doesn't feel like the right or complete solution - I'd rather check the type of the field than the value, and I feel like this might be an issue for other types too, but this is my workaround for the moment.

Using Postgres 9.5.