### PR TITLE
Generate URI-safe IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ const store = fortune({ ... }, {
 - `isNative`: Whether or not to use native bindings, requires `pg-native` module, which is an optional dependency of this one. Default: `false`.
 - `typeMap`: an object keyed by type name and valued by table name.
 - `primaryKeyType`: Data type of the primary key. May be `String`, `Number`, or a string for custom type. Default: `String`.
-- `generatePrimaryKey`: A function that accepts one argument, the `type` of the record, and returns either a `String` or `Number`. By default, it returns 15 random bytes, base64 encoded. Set this to a falsy value like `null` to turn this off.
+- `generatePrimaryKey`: A function that accepts one argument, the `type` of the record, and returns either a `String` or `Number`. By default,
+  it returns 15 random bytes, base64 encoded in a URI-safe way. Set this to a falsey value like `null` to turn this off.
 - `useForeignKeys`: Whether or not to use foreign key constraint, optional since it will only be applied to non-array fields. Default: `false`.
 
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -101,6 +101,7 @@ function getCode (error) {
 
 function defaultPrimaryKey () {
   return randomBytes(15).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 


### PR DESCRIPTION
Resolves #21 

The base62 alphabet contains only URI-safe values 👌 