### PR TITLE
Bugfix: ssl and isNative=true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,8 +83,20 @@ module.exports = Adapter => class PostgreSQLAdapter extends Adapter {
           user,
           password,
           host: params.hostname,
-          port: params.port,
-          ssl: 'ssl' in params.query
+          port: params.port
+        }
+
+        if(params.query['ssl']) {
+          //TODO: note probably in some future, more sslModes should be supported
+          console.log('ssl mode detected')
+          if(isNative) {
+            console.info(`Translating to sslMode=require`)
+            connection['sslMode'] = 'require'
+          }
+          else {
+            console.info(`Translating to ssl=true`)
+            connection['ssl'] = true
+          }
         }
       }
 


### PR DESCRIPTION
If pg-native is used together with SSL, the parameter `?ssl=true`
needs different translation.